### PR TITLE
Memory leak fix and top/bottom bar height ignore option.

### DIFF
--- a/Pager/PagerController.swift
+++ b/Pager/PagerController.swift
@@ -61,6 +61,8 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 	open var centerCurrentTab: Bool = false
 	open var fixFormerTabsPositions: Bool = false
 	open var fixLaterTabsPosition: Bool = false
+	open var ignoreTopBarHeight: Bool = false
+	open var ignoreBottomBarHeight: Bool = false
 	fileprivate var tabViews: [UIView] = []
 	fileprivate var tabControllers: [UIViewController] = []
 
@@ -283,7 +285,7 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 
 	func layoutSubViews() {
 		var topLayoutGuide: CGFloat = 0.0
-		if self.navigationController?.navigationBar.isTranslucent != false {
+		if !ignoreTopBarHeight && self.navigationController?.navigationBar.isTranslucent != false {
 			topLayoutGuide = UIApplication.shared.isStatusBarHidden ? 0.0 : 20.0
 
 			if let nav = self.navigationController {
@@ -305,7 +307,7 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 
 		frame.size.height = self.view.frame.height - (topLayoutGuide + self.tabsView!.frame.height + tabTopOffset)
 
-		if self.tabBarController != nil && self.tabBarController?.tabBar.isTranslucent == true {
+		if !ignoreBottomBarHeight && self.tabBarController != nil && self.tabBarController?.tabBar.isTranslucent == true {
 			frame.size.height -= self.tabBarController!.tabBar.frame.height
 		}
 

--- a/Pager/PagerController.swift
+++ b/Pager/PagerController.swift
@@ -47,8 +47,8 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 	open var tabsTextColor: UIColor = UIColor.white
 	open var selectedTabTextColor = UIColor.white
 	open var tabsImageViewContentMode = UIViewContentMode.scaleAspectFit
-	open var dataSource: PagerDataSource!
-	open var delegate: PagerDelegate?
+	open weak var dataSource: PagerDataSource?
+	open weak var delegate: PagerDelegate?
 	open var tabHeight: CGFloat = 44.0
 	open var tabTopOffset: CGFloat = 0.0
 	open var tabOffset: CGFloat = 56.0
@@ -182,8 +182,9 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 		self.underlineStroke.removeFromSuperview()
 
 		// Get tabCount from dataSource
-
-		if let num = self.dataSource!.numberOfTabs?(self) {
+		
+		if let dataSource = self.dataSource,
+			let num = dataSource.numberOfTabs?(self) {
 			self.tabCount = num
 		} else {
 			self.tabCount = tabControllers.count
@@ -400,14 +401,17 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 
 
 	func tabViewAtIndex(_ index: Int) -> TabView? {
-		if index >= self.tabCount {
-			return nil
+		guard
+			let dataSource = self.dataSource,
+			index < self.tabCount
+			else {
+				return nil
 		}
 
 		if (self.tabs[index] as UIView?) == nil {
 
 			var tabViewContent = UIView()
-			if let tab = self.dataSource.tabViewForIndex?(index, pager: self) {
+			if let tab = dataSource.tabViewForIndex?(index, pager: self) {
 				tabViewContent = tab
 			} else {
 				tabViewContent = tabViews[index]
@@ -465,18 +469,21 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 	}
 
 	func viewControllerAtIndex(_ index: Int) -> UIViewController? {
-		if index >= self.tabCount || index < 0 {
-			return nil
+		guard
+			let dataSource = self.dataSource,
+			index < self.tabCount && index >= 0
+			else {
+				return nil
 		}
 
 		if (self.contents[index] as UIViewController?) == nil {
 			var viewController: UIViewController
 
-			if self.dataSource!.responds(to: #selector(PagerDataSource.controllerForTabAtIndex(_: pager:))) {
-				viewController = self.dataSource.controllerForTabAtIndex!(index, pager: self)
-			} else if self.dataSource!.responds(to: #selector(PagerDataSource.viewForTabAtIndex(_: pager:))) {
+			if dataSource.responds(to: #selector(PagerDataSource.controllerForTabAtIndex(_: pager:))) {
+				viewController = dataSource.controllerForTabAtIndex!(index, pager: self)
+			} else if dataSource.responds(to: #selector(PagerDataSource.viewForTabAtIndex(_: pager:))) {
 
-				let view: UIView = self.dataSource.viewForTabAtIndex!(index, pager: self)
+				let view: UIView = dataSource.viewForTabAtIndex!(index, pager: self)
 
 				// Adjust view's bounds to match the pageView's bounds
 				let pageView: UIView = self.view.viewWithTag(34)!

--- a/Pager/ViewController.swift
+++ b/Pager/ViewController.swift
@@ -33,7 +33,13 @@ class ViewController: PagerController, PagerDataSource {
 		customizeTab()
 
 		if let controller = controller4 as? GreyViewController {
-			controller.didSelectRow = pushGreyDetailViewController
+			controller.didSelectRow = { [weak self] (text: String) in
+				let storyboard = UIStoryboard(name: "Main", bundle: nil)
+				if let detail = storyboard.instantiateViewController(withIdentifier: "greyTableDetail") as? GreyDetailViewController {
+					detail.text = text
+					self?.navigationController?.pushViewController(detail, animated: true)
+				}
+			}
 		}
 	}
 
@@ -63,15 +69,6 @@ class ViewController: PagerController, PagerDataSource {
 	// Programatically selecting a tab. This function is getting called on AppDelegate
 	func changeTab() {
 		self.selectTabAtIndex(4)
-	}
-
-
-	func pushGreyDetailViewController(text: String) {
-		let storyboard = UIStoryboard(name: "Main", bundle: nil)
-		if let detail = storyboard.instantiateViewController(withIdentifier: "greyTableDetail") as? GreyDetailViewController {
-			detail.text = text
-			self.navigationController?.pushViewController(detail, animated: true)
-		}
 	}
 
 


### PR DESCRIPTION
Data source and delegate variables are set to weak to prevent a retain cycle, which prevents the PagerController objects to deallocate from memory.

ignoreTopBarHeight and ignoreBottomBarHeight options are added so the view can be sized appropriately if it is embedded in as a child view controller (through Container View in storyboard).