### PR TITLE
fix Cyclomatic Complexity Violation warning

### DIFF
--- a/Pager/PagerController.swift
+++ b/Pager/PagerController.swift
@@ -173,9 +173,9 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 
 	func defaultSetup() {
 		// Empty tabs and contents
-        self.tabs.forEach { (tabView) in
-            tabView?.removeFromSuperview()
-        }
+		self.tabs.forEach { (tabView) in
+			tabView?.removeFromSuperview()
+		}
 
 		self.tabs.removeAll(keepingCapacity: true)
 		self.contents.removeAll(keepingCapacity: true)

--- a/Pager/PagerController.swift
+++ b/Pager/PagerController.swift
@@ -173,9 +173,9 @@ open class PagerController: UIViewController, UIPageViewControllerDataSource, UI
 
 	func defaultSetup() {
 		// Empty tabs and contents
-		for tabView in self.tabs {
-			tabView?.removeFromSuperview()
-		}
+        self.tabs.forEach { (tabView) in
+            tabView?.removeFromSuperview()
+        }
 
 		self.tabs.removeAll(keepingCapacity: true)
 		self.contents.removeAll(keepingCapacity: true)


### PR DESCRIPTION
I changed the function that removes the tabView from superview due to complexity and it fixed the Cyclomatic Complexity Violation warning